### PR TITLE
feat(BA-2597): Add persistence for messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ For development without Docker:
 
    ```bash
    # Install Python 3.13 with pyenv
-   pyenv install 3.13.0
+   pyenv install 3.13
 
    # Set local Python version for this project
-   pyenv local 3.13.0
+   pyenv local 3.13
 
    # Verify Python version
    python --version

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -40,7 +40,7 @@ async def on_cleanup(app: web.Application) -> None:
 
 
 async def healthz(_: web.Request) -> web.Response:
-    return web.json_response({"ok": True})
+    return web.json_response({"status": "ok"})
 
 
 async def index(_: web.Request) -> web.FileResponse:

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -9,6 +9,7 @@ from types import FrameType
 
 from aiohttp import web
 
+from server.models import json_dumps
 from server.redis import RedisManager, install_redis_manager
 from server.ws import WSMessageRouter, install_ws_router
 
@@ -16,15 +17,17 @@ logger = logging.getLogger(__name__)
 
 
 STATIC_RESOURCES_DIR = Path(__file__).resolve().parent.parent / "static"
+MINUTES_IN_HOUR = 60
+HOUR_IN_DAY = 24
 
 
 async def on_startup(app: web.Application) -> None:
     redis_manager: RedisManager = app["redis_manager"]
     logger.info("Connecting to Redis...")
     await redis_manager.connect()
-    logger.info("Redis connected! Establishing pubsub connection...")
+    logger.info("Redis connected! Starting stream listener...")
     await redis_manager.start_listen()
-    logger.info("The server is now ready to listen to Redis messages!")
+    logger.info("The server is now ready to listen to Redis stream messages!")
 
 
 async def on_cleanup(app: web.Application) -> None:
@@ -47,12 +50,32 @@ async def index(_: web.Request) -> web.FileResponse:
     return web.FileResponse(STATIC_RESOURCES_DIR / "index.html")
 
 
+async def get_messages(req: web.Request) -> web.Response:
+    minutes_str = req.query.get("minutes", "30")
+    if not minutes_str.isdigit():
+        raise web.HTTPBadRequest(reason="minutes is not a valid integer!")
+    minutes = int(minutes_str)
+    if minutes < 1:
+        raise web.HTTPBadRequest(reason="minutes must be a positive number!")
+    if minutes > MINUTES_IN_HOUR * HOUR_IN_DAY:
+        raise web.HTTPBadRequest(reason="minutes cannot be more than 24 hours!")
+
+    redis_manager: RedisManager = req.app["redis_manager"]
+    try:
+        messages = await redis_manager.fetch_history(minutes=minutes)
+        return web.json_response({"messages": messages}, dumps=json_dumps)
+    except Exception as exc:
+        logger.exception("Failed to fetch message history")
+        return web.json_response({"error": str(exc)}, status=500)
+
+
 def create_app(redis_url: str) -> web.Application:
     app = web.Application()
     app.add_routes(
         [
             web.get("/", index),
             web.get("/healthz", healthz),
+            web.get("/messages", get_messages),
             web.static("/static", STATIC_RESOURCES_DIR),
         ]
     )

--- a/src/server/redis.py
+++ b/src/server/redis.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-from collections.abc import Awaitable, Callable
+import time
+from collections.abc import Awaitable, Callable, Generator
+from typing import Any
 
 import redis.asyncio as redis
 from aiohttp import web
@@ -16,14 +18,20 @@ logger = logging.getLogger(__name__)
 MessageHandler = Callable[[ChatMessage], Awaitable[None]]
 
 
+SECONDS_IN_MINUTE = 60
+MS_IN_SECOND = 1_000
+
+
 class RedisManager:
-    CHANNEL = "chat:messages"
+    STREAM_KEY = "chat:messages"
+    MAX_STREAM_LENGTH = 10_000
 
     def __init__(self, redis_url: str) -> None:
         self.redis_url = redis_url
         self.client: redis.Redis | None = None
         self._listener_task: asyncio.Task[None] | None = None
         self._message_handler: MessageHandler | None = None
+        self._last_id: str = "$"  # Start reading from new messages
 
     async def connect(self) -> None:
         if self.client:
@@ -48,12 +56,38 @@ class RedisManager:
     def set_message_handler(self, handler: MessageHandler) -> None:
         self._message_handler = handler
 
+    async def fetch_history(self, minutes: int = 30) -> list[ChatMessage]:
+        if self.client is None:
+            raise RuntimeError("Redis client not connected!")
+
+        current_time_ms = int(time.time() * MS_IN_SECOND)
+        start_time_ms = current_time_ms - (minutes * SECONDS_IN_MINUTE * MS_IN_SECOND)
+
+        # XRANGE with timestamp-based IDs: format is "timestamp-sequence"
+        # Using start_time_ms-0 to get all messages from that timestamp onward
+        response = await self.client.xrange(
+            name=self.STREAM_KEY,
+            min=f"{start_time_ms}-0",
+            max="+",  # Current time
+        )
+
+        messages = [
+            message for _, message in self.extract_messages_from_response(response)
+        ]
+
+        return messages
+
     async def publish_message(self, message: ChatMessage) -> None:
         if self.client is None:
             raise RuntimeError("Redis client not connected!")
 
         payload = json_dumps(message)
-        await self.client.publish(self.CHANNEL, payload)  # pyright: ignore[reportUnknownMemberType]
+        await self.client.xadd(
+            name=self.STREAM_KEY,
+            fields={"data": payload},
+            maxlen=self.MAX_STREAM_LENGTH,
+            approximate=True,  # More efficient auto-trimming
+        )
 
     async def start_listen(self) -> None:
         if not self.client:
@@ -65,42 +99,55 @@ class RedisManager:
         assert self.client
 
         try:
-            async with self.client.pubsub() as pubsub:  # pyright: ignore[reportUnknownMemberType]
-                await pubsub.subscribe(self.CHANNEL)  # pyright: ignore[reportUnknownMemberType]
+            while True:
+                stream_data = await self.client.xread(
+                    streams={self.STREAM_KEY: self._last_id},
+                    count=100,
+                    block=5 * MS_IN_SECOND,
+                )
 
-                async for message in pubsub.listen():  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
-                    if message["type"] == "message":
-                        try:
-                            data = json_loads(message["data"])  # pyright: ignore[reportUnknownArgumentType]
-                            if self._message_handler:
-                                await self._message_handler(data)
-                        except ValueError:
-                            logger.exception(
-                                "Failed to parse message with data %s!",
-                                message["data"],  # pyright: ignore[reportUnknownArgumentType]
-                            )
-                        except Exception:
-                            logger.exception(
-                                "Unknown exception occured while receiving message %s.",
-                                message,  # pyright: ignore[reportUnknownArgumentType]
-                            )
-                    elif message["type"] == "subscribe":
-                        logger.debug(
-                            "Subscribe message received. message=%s",
-                            message,  # pyright: ignore[reportUnknownArgumentType]
-                        )
-                    else:
-                        logger.warning(
-                            "Unknown message type %s! message=%s",
-                            message["type"],  # pyright: ignore[reportUnknownArgumentType]
-                            message,  # pyright: ignore[reportUnknownArgumentType]
-                        )
+                if not stream_data:
+                    # Timeout, no new messages in last 5 seconds
+                    continue
+
+                for _, response in stream_data:
+                    messages = self.extract_messages_from_response(response)
+                    for message_id, message in messages:
+                        self._last_id = message_id
+                        if self._message_handler:
+                            await self._message_handler(message)
         except asyncio.CancelledError as exc:
             logger.info("Client listener is cancelled.")
             raise exc
         except Exception:
             logger.exception("Unknown exception occured during listening loop.")
             return
+
+    def extract_messages_from_response(
+        self, response: list[tuple[str, dict[str, Any]]]
+    ) -> Generator[tuple[str, ChatMessage]]:
+        for message_id, fields in response:
+            payload = fields.get("data")
+            if not payload:
+                logger.warning("Message %s has no 'data' field!", message_id)
+                continue
+
+            try:
+                chat_message = json_loads(payload)
+                yield message_id, chat_message
+            except ValueError:
+                logger.exception(
+                    "Failed to parse message with id %s and payload %s!",
+                    message_id,
+                    payload,
+                    exc_info=True,
+                )
+            except Exception:
+                logger.warning(
+                    "Unknown exception occured while receiving message %s",
+                    message_id,
+                    exc_info=True,
+                )
 
 
 def install_redis_manager(app: web.Application, redis_url: str) -> RedisManager:

--- a/src/server/ws.py
+++ b/src/server/ws.py
@@ -8,7 +8,7 @@ from enum import Enum, auto
 
 from aiohttp import WSCloseCode, WSMessage, WSMsgType, web
 
-from server.models import ChatMessage
+from server.models import ChatMessage, json_dumps, json_loads
 from server.redis import RedisManager
 
 logger = logging.getLogger(__name__)
@@ -96,7 +96,7 @@ class WSMessageRouter:
         data = message.data
 
         try:
-            obj = ChatMessage.from_json(data)
+            obj = json_loads(data)
         except ValueError:
             # Drop garbage input instead of crashing the room.
             logger.warning("Failed to parse message %s", data, exc_info=True)
@@ -108,7 +108,7 @@ class WSMessageRouter:
         await self.redis.publish_message(obj)
 
     async def _broadcast_to_local_peers(self, message: ChatMessage) -> None:
-        payload = message.to_json()
+        payload = json_dumps(message)
 
         # Snapshotting the clients set is necessary here, as during await a
         # client can disconnect, causing a mutation of the clients set, which

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -7,7 +7,7 @@ from aiohttp import web
 from aiohttp.client_ws import ClientWebSocketResponse
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
 
-from server.models import ChatMessage
+from server.models import ChatMessage, json_dumps
 from server.ws import WSMessageRouter
 
 MessageHandler = Callable[[ChatMessage], Awaitable[None]]
@@ -78,7 +78,7 @@ class TestWebSocketE2E(AioHTTPTestCase):
         )
 
         # Client 1 sends a message
-        await session1.send_str(test_message.to_json())
+        await session1.send_str(json_dumps(test_message))
 
         # Both clients should receive the message (fan-out behavior)
         # Give some time for the message to propagate
@@ -125,15 +125,15 @@ class TestWebSocketE2E(AioHTTPTestCase):
         ]
 
         # Client 1 sends first message
-        await session1.send_str(messages[0].to_json())
+        await session1.send_str(json_dumps(messages[0]))
         await asyncio.sleep(0.1)
 
         # Client 2 sends second message
-        await session2.send_str(messages[1].to_json())
+        await session2.send_str(json_dumps(messages[1]))
         await asyncio.sleep(0.1)
 
         # Client 1 sends third message
-        await session1.send_str(messages[2].to_json())
+        await session1.send_str(json_dumps(messages[2]))
         await asyncio.sleep(0.1)
 
         # Verify all messages were published to Redis
@@ -189,7 +189,7 @@ class TestWebSocketE2E(AioHTTPTestCase):
 
         # Send valid message to verify connection is still working
         valid_message = ChatMessage(text="Valid message", type="message", ts=1004)
-        await session.send_str(valid_message.to_json())
+        await session.send_str(json_dumps(valid_message))
         await asyncio.sleep(0.1)
 
         # This should work

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from server.models import ChatMessage
+from server.models import ChatMessage, json_dumps
 from server.redis import RedisManager
 
 
@@ -99,7 +99,7 @@ class TestRedisManager:
         await redis_manager.publish_message(sample_message)
 
         mock_client.publish.assert_called_once_with(
-            RedisManager.CHANNEL, sample_message.to_json()
+            RedisManager.CHANNEL, json_dumps(sample_message)
         )
 
     async def test_publish_message_no_client(
@@ -139,7 +139,7 @@ class TestRedisManager:
         # Mock message iteration
         messages = [
             {"type": "subscribe", "data": None},
-            {"type": "message", "data": sample_message.to_json()},
+            {"type": "message", "data": json_dumps(sample_message)},
         ]
         mock_pubsub.listen.return_value.__aiter__ = lambda self: iter(messages)
 

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -98,8 +98,11 @@ class TestRedisManager:
 
         await redis_manager.publish_message(sample_message)
 
-        mock_client.publish.assert_called_once_with(
-            RedisManager.CHANNEL, json_dumps(sample_message)
+        mock_client.xadd.assert_called_once_with(
+            name=RedisManager.STREAM_KEY,
+            fields={"data": json_dumps(sample_message)},
+            maxlen=RedisManager.MAX_STREAM_LENGTH,
+            approximate=True,
         )
 
     async def test_publish_message_no_client(
@@ -131,24 +134,21 @@ class TestRedisManager:
         redis_manager.client = mock_client
         redis_manager._message_handler = mock_handler
 
-        # Mock pubsub context manager
-        mock_pubsub = AsyncMock()
-        mock_client.pubsub.return_value.__aenter__.return_value = mock_pubsub
-        mock_client.pubsub.return_value.__aexit__.return_value = None
-
-        # Mock message iteration
-        messages = [
-            {"type": "subscribe", "data": None},
-            {"type": "message", "data": json_dumps(sample_message)},
+        # Mock XREAD response
+        message_id = "1234567890-0"
+        mock_client.xread.return_value = [
+            [
+                RedisManager.STREAM_KEY,
+                [(message_id, {"data": json_dumps(sample_message)})],
+            ]
         ]
-        mock_pubsub.listen.return_value.__aiter__ = lambda self: iter(messages)
 
         # Run listen loop once and cancel
         with contextlib.suppress(TimeoutError):
             await asyncio.wait_for(redis_manager._listen_loop(), timeout=0.1)
 
-        mock_pubsub.subscribe.assert_called_once_with(RedisManager.CHANNEL)
-        mock_handler.assert_called_once_with(sample_message)
+        mock_client.xread.assert_called()
+        mock_handler.assert_called_with(sample_message)
 
     async def test_listen_loop_invalid_message(
         self, redis_manager: RedisManager
@@ -193,4 +193,4 @@ class TestRedisManager:
             await redis_manager._listen_loop()
 
     def test_channel_constant(self) -> None:
-        assert RedisManager.CHANNEL == "chat:messages"
+        assert RedisManager.STREAM_KEY == "chat:messages"

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from aiohttp import WSCloseCode, WSMessage, WSMsgType
 
-from server.models import ChatMessage
+from server.models import ChatMessage, json_dumps
 from server.ws import SEND_TIMEOUT, WS_CLOSE_TIMEOUT, PeerStatus, WSMessageRouter
 
 # Test constants
@@ -148,7 +148,7 @@ class TestWSMessageRouter:
         self, ws_router: WSMessageRouter, sample_message: ChatMessage
     ) -> None:
         message = WSMessage(
-            type=WSMsgType.TEXT, data=sample_message.to_json(), extra=None
+            type=WSMsgType.TEXT, data=json_dumps(sample_message), extra=None
         )
 
         await ws_router._handle_text(message)


### PR DESCRIPTION
This change adds some ephemeral persistence (30 minutes or whenever Redis server goes down) to the chat app so that the user does not lose all chat log when the browser window closes or refreshes.